### PR TITLE
Bump Go above v1.11 to fix failing sys calls on mac OS monterey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ GITHUB_REPO_HOST_AND_PATH := github.com/$(GITHUB_REPO_OWNER)/$(GITHUB_REPO_NAME)
 IMAGE_NAME := artifactory.nordstrom.com/docker/app00738/kubelogin
 BUILD := build
 CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-CURRENT_TAG := v0.0.6d
-GOLANG_TOOLCHAIN_VERSION := 1.9.1
+CURRENT_TAG := v0.0.6e
+GOLANG_TOOLCHAIN_VERSION := 1.17.6
 
 .PHONY: image/build image/push
 .PHONY: release/tag/local release/tag/push


### PR DESCRIPTION
Users who have upgraded to mac OS  Monterey are unable to execute kubelogin because of [bsdthread_register error](https://github.com/golang/go/wiki/MacOS12BSDThreadRegisterIssue)

To fix this, Go v1.11+ must be used when compiling the binary